### PR TITLE
Fixes #8 (allow multiple entrypoints in builds)

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,12 @@ function assetCopier (bundler) {
       pkg = require(bundler.mainAsset.package.pkgfile)
     } else {
       try {
-        pkg = await bundler.mainBundle.entryAsset.getPackage()
+        if (bundler.mainBundle.childBundles.values().next().value) {
+          bundle = bundler.mainBundle.childBundles.values().next().value
+          pkg = await bundler.mainBundle.childBundles.values().next().value.entryAsset.getPackage()
+        } else {
+          pkg = await bundler.mainBundle.entryAsset.getPackage()
+        }
       } catch (error) {
         console.error(error)
       }


### PR DESCRIPTION
Here is what I was talking about in #8 

You can test it by doing `parcel index.html index_debug.html` as opposed to the normal single html / js file entrypoint.